### PR TITLE
Hotfix: Inconsistent Waypoint Skipping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
   testImplementation 'junit:junit:4.12'
 }
 
-/*
+
 mavenPublishing {
   publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
@@ -101,4 +101,3 @@ mavenPublishing {
     }
   }
 }
-*/

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
   testImplementation 'junit:junit:4.12'
 }
 
+/*
 mavenPublishing {
   publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
@@ -100,3 +101,4 @@ mavenPublishing {
     }
   }
 }
+*/

--- a/src/main/java/dev/narlyx/tweetybird/Runtime.java
+++ b/src/main/java/dev/narlyx/tweetybird/Runtime.java
@@ -200,6 +200,9 @@ public class Runtime extends Thread {
       } else {
         tweetyBird.log("Driver stop and hold not called: TweetyBird not engaged");
       }
+      if (!tweetyBird.waypointQueue.getUpdated()) {
+        tweetyBird.waypointQueue.clearToCurrentIndex();
+      }
     } else { // Sending movement
       busy = true;
       if (engaged) {

--- a/src/main/java/dev/narlyx/tweetybird/Runtime.java
+++ b/src/main/java/dev/narlyx/tweetybird/Runtime.java
@@ -200,9 +200,6 @@ public class Runtime extends Thread {
       } else {
         tweetyBird.log("Driver stop and hold not called: TweetyBird not engaged");
       }
-      if (!tweetyBird.waypointQueue.getUpdated()) {
-        tweetyBird.waypointQueue.clear();
-      }
     } else { // Sending movement
       busy = true;
       if (engaged) {

--- a/src/main/java/dev/narlyx/tweetybird/WaypointQueue.java
+++ b/src/main/java/dev/narlyx/tweetybird/WaypointQueue.java
@@ -53,7 +53,8 @@ public class WaypointQueue {
       currentIndex += 1;
       tweetyBird.log("Queue incremented");
     } else {
-      tweetyBird.log("Queue not large enough to increment");
+      tweetyBird.log("Clearing Queue - Queue not large enough to increment");
+      clear();
     }
   }
 

--- a/src/main/java/dev/narlyx/tweetybird/WaypointQueue.java
+++ b/src/main/java/dev/narlyx/tweetybird/WaypointQueue.java
@@ -75,6 +75,26 @@ public class WaypointQueue {
   }
 
   /**
+   * Clears out waypoints in queue from 0 to current index (inclusive)
+   */
+  public void clearToCurrentIndex(){
+    updated = true;
+    ArrayList<Waypoint> tempQueue = new ArrayList<>();
+    Waypoint currentWaypoint = new Waypoint(
+            tweetyBird.odometer.getX(),
+            tweetyBird.odometer.getY(),
+            tweetyBird.odometer.getZ());
+    for(int i = currentIndex; i < queue.size(); i++){
+      tempQueue.add(getWaypoint(i));
+    }
+    queue.clear();
+    queue.add(currentWaypoint);
+    queue.addAll(tempQueue);
+    currentIndex = 0;
+    tweetyBird.log("Queue cleared up to current index");
+  }
+
+  /**
    * Returns the current index
    * @return Current index
    */

--- a/src/main/java/dev/narlyx/tweetybird/WaypointQueue.java
+++ b/src/main/java/dev/narlyx/tweetybird/WaypointQueue.java
@@ -53,8 +53,7 @@ public class WaypointQueue {
       currentIndex += 1;
       tweetyBird.log("Queue incremented");
     } else {
-      tweetyBird.log("Clearing Queue - Queue not large enough to increment");
-      clear();
+      tweetyBird.log("Queue not large enough to increment");
     }
   }
 


### PR DESCRIPTION
Created a new method in WaypointQueue that clears items before a specified index. This allows passed waypoints to be cleared without effecting newly added waypoints. New method was implemented into Runtime. Also commented out mavenPublishing lines in build.gradle to be able to build without internet connection.

Tested over 15 runs with success.

Solution to #11